### PR TITLE
Ot168 98 - TestimonialControllerTest

### DIFF
--- a/src/main/java/com/alkemy/ong/data/entities/TestimonialEntity.java
+++ b/src/main/java/com/alkemy/ong/data/entities/TestimonialEntity.java
@@ -9,6 +9,7 @@ import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Entity
 @Table(name = "testimonials")
@@ -44,5 +45,19 @@ public class TestimonialEntity {
 
     @Builder.Default
     private Boolean deleted = Boolean.FALSE;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TestimonialEntity that = (TestimonialEntity) o;
+        return Objects.equals(id,that.id)
+                && Objects.equals(name,that.name)
+                && Objects.equals(image,that.image)
+                && Objects.equals(content,that.content)
+                && Objects.equals(createdAt, that.createdAt)
+                && Objects.equals(updatedAt, that.updatedAt)
+                && Objects.equals(deleted, that.deleted);
+    }
 
 }

--- a/src/main/java/com/alkemy/ong/data/gateways/DefaultTestimonialGateway.java
+++ b/src/main/java/com/alkemy/ong/data/gateways/DefaultTestimonialGateway.java
@@ -29,12 +29,13 @@ public class DefaultTestimonialGateway implements TestimonialGateway {
         return toModel(testimonialRepository.save(toEntity(testimonial)));
     }
 
+
     public Testimonial update(Long id, Testimonial testimonial) {
         TestimonialEntity entity = testimonialRepository.findById(id).orElseThrow(() -> new ResourceNotFoundException("The ID doesn't exist."));
         entity.setName(testimonial.getName());
         entity.setContent(testimonial.getContent());
         entity.setImage(testimonial.getImage());
-        entity.setUpdatedAt(LocalDateTime.now());
+       //entity.setUpdatedAt(LocalDateTime.now());
         return toModel(testimonialRepository.save(entity));
     }
 
@@ -48,25 +49,27 @@ public class DefaultTestimonialGateway implements TestimonialGateway {
                 .findAll(PageRequest.of(pageNumber, DEFAULT_PAGE_SIZE)),"/testimonials?page="), Testimonial.class);
     }
 
+    //TODO: Borrar lineas comentadas si el rework funciona!
     private static Testimonial toModel(TestimonialEntity testimonialEntity) {
         return Testimonial.builder()
                 .id(testimonialEntity.getId())
                 .name(testimonialEntity.getName())
                 .image(testimonialEntity.getImage())
                 .content(testimonialEntity.getContent())
-                .createdAt(testimonialEntity.getCreatedAt())
-                .updatedAt(testimonialEntity.getUpdatedAt())
+                //.createdAt(testimonialEntity.getCreatedAt())
+                //.updatedAt(testimonialEntity.getUpdatedAt())
                 .build();
     }
 
+    //TODO: Borrar lineas comentadas si el rework funciona!
     private TestimonialEntity toEntity(Testimonial testimonialModel) {
         return TestimonialEntity.builder()
                 .id(testimonialModel.getId())
                 .name(testimonialModel.getName())
                 .image(testimonialModel.getImage())
                 .content(testimonialModel.getContent())
-                .createdAt(testimonialModel.getCreatedAt())
-                .updatedAt(testimonialModel.getUpdatedAt())
+                //.createdAt(testimonialModel.getCreatedAt())
+                //.updatedAt(testimonialModel.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/alkemy/ong/data/gateways/DefaultTestimonialGateway.java
+++ b/src/main/java/com/alkemy/ong/data/gateways/DefaultTestimonialGateway.java
@@ -10,7 +10,6 @@ import com.alkemy.ong.domain.testimonial.TestimonialGateway;
 import lombok.SneakyThrows;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
-import java.time.LocalDateTime;
 import static com.alkemy.ong.data.utils.PaginationUtils.*;
 
 @Component
@@ -29,13 +28,11 @@ public class DefaultTestimonialGateway implements TestimonialGateway {
         return toModel(testimonialRepository.save(toEntity(testimonial)));
     }
 
-
     public Testimonial update(Long id, Testimonial testimonial) {
         TestimonialEntity entity = testimonialRepository.findById(id).orElseThrow(() -> new ResourceNotFoundException("The ID doesn't exist."));
         entity.setName(testimonial.getName());
         entity.setContent(testimonial.getContent());
         entity.setImage(testimonial.getImage());
-       //entity.setUpdatedAt(LocalDateTime.now());
         return toModel(testimonialRepository.save(entity));
     }
 
@@ -49,27 +46,21 @@ public class DefaultTestimonialGateway implements TestimonialGateway {
                 .findAll(PageRequest.of(pageNumber, DEFAULT_PAGE_SIZE)),"/testimonials?page="), Testimonial.class);
     }
 
-    //TODO: Borrar lineas comentadas si el rework funciona!
     private static Testimonial toModel(TestimonialEntity testimonialEntity) {
         return Testimonial.builder()
                 .id(testimonialEntity.getId())
                 .name(testimonialEntity.getName())
                 .image(testimonialEntity.getImage())
                 .content(testimonialEntity.getContent())
-                //.createdAt(testimonialEntity.getCreatedAt())
-                //.updatedAt(testimonialEntity.getUpdatedAt())
                 .build();
     }
 
-    //TODO: Borrar lineas comentadas si el rework funciona!
     private TestimonialEntity toEntity(Testimonial testimonialModel) {
         return TestimonialEntity.builder()
                 .id(testimonialModel.getId())
                 .name(testimonialModel.getName())
                 .image(testimonialModel.getImage())
                 .content(testimonialModel.getContent())
-                //.createdAt(testimonialModel.getCreatedAt())
-                //.updatedAt(testimonialModel.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/alkemy/ong/domain/testimonial/Testimonial.java
+++ b/src/main/java/com/alkemy/ong/domain/testimonial/Testimonial.java
@@ -1,7 +1,6 @@
 package com.alkemy.ong.domain.testimonial;
 
 import lombok.*;
-import java.time.LocalDateTime;
 
 @Getter
 @Setter
@@ -11,16 +10,7 @@ import java.time.LocalDateTime;
 public class Testimonial {
 
     private Long id;
-
     private String name;
-
     private String image;
-
     private String content;
-
-    //private LocalDateTime createdAt;
-
-    //private LocalDateTime updatedAt;
-
-    //private Boolean deleted;
 }

--- a/src/main/java/com/alkemy/ong/domain/testimonial/Testimonial.java
+++ b/src/main/java/com/alkemy/ong/domain/testimonial/Testimonial.java
@@ -18,9 +18,9 @@ public class Testimonial {
 
     private String content;
 
-    private LocalDateTime createdAt;
+    //private LocalDateTime createdAt;
 
-    private LocalDateTime updatedAt;
+    //private LocalDateTime updatedAt;
 
-    private Boolean deleted;
+    //private Boolean deleted;
 }

--- a/src/main/java/com/alkemy/ong/web/controllers/TestimonialController.java
+++ b/src/main/java/com/alkemy/ong/web/controllers/TestimonialController.java
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import java.time.LocalDateTime;
 import java.util.List;
 import static java.util.stream.Collectors.toList;
 import static com.alkemy.ong.web.utils.WebUtils.*;
@@ -53,26 +52,21 @@ public class TestimonialController {
                 body(pageDTOMapper.toPageDTO(testimonialService.findAll(numberPage), TestimonialDTO.class));
     }
 
-    //TODO: Borrar lineas comentadas si el rework funciona!
     private Testimonial toModel(TestimonialDTO testimonialDTO) {
         return Testimonial.builder()
                 .id(testimonialDTO.getId())
                 .name(testimonialDTO.getName())
                 .image(testimonialDTO.getImage())
                 .content(testimonialDTO.getContent())
-                //.createdAt(testimonialDTO.getCreatedAt())
-                //.updatedAt(testimonialDTO.getUpdatedAt())
                 .build();
     }
-    //TODO: Borrar lineas comentadas si el rework funciona!
+
     private TestimonialDTO toDto(Testimonial testimonial) {
         return TestimonialDTO.builder()
                 .id(testimonial.getId())
                 .name(testimonial.getName())
                 .image(testimonial.getImage())
                 .content(testimonial.getContent())
-                //.createdAt(testimonial.getCreatedAt())
-                //.updatedAt(testimonial.getUpdatedAt())
                 .build();
     }
 
@@ -80,7 +74,6 @@ public class TestimonialController {
         return testimonialList.stream().map(this::toDto).collect(toList());
     }
 
-    //TODO: Borrar lineas comentadas si el rework funciona!
     @Getter
     @Setter
     @Builder
@@ -97,10 +90,6 @@ public class TestimonialController {
 
         @NotNull(message = "Field 'content' is required.")
         private String content;
-
-        //private LocalDateTime createdAt;
-
-        //private LocalDateTime updatedAt;
 
         private String type = "testimonial";
     }

--- a/src/main/java/com/alkemy/ong/web/controllers/TestimonialController.java
+++ b/src/main/java/com/alkemy/ong/web/controllers/TestimonialController.java
@@ -53,25 +53,26 @@ public class TestimonialController {
                 body(pageDTOMapper.toPageDTO(testimonialService.findAll(numberPage), TestimonialDTO.class));
     }
 
+    //TODO: Borrar lineas comentadas si el rework funciona!
     private Testimonial toModel(TestimonialDTO testimonialDTO) {
         return Testimonial.builder()
                 .id(testimonialDTO.getId())
                 .name(testimonialDTO.getName())
                 .image(testimonialDTO.getImage())
                 .content(testimonialDTO.getContent())
-                .createdAt(testimonialDTO.getCreatedAt())
-                .updatedAt(testimonialDTO.getUpdatedAt())
+                //.createdAt(testimonialDTO.getCreatedAt())
+                //.updatedAt(testimonialDTO.getUpdatedAt())
                 .build();
     }
-
+    //TODO: Borrar lineas comentadas si el rework funciona!
     private TestimonialDTO toDto(Testimonial testimonial) {
         return TestimonialDTO.builder()
                 .id(testimonial.getId())
                 .name(testimonial.getName())
                 .image(testimonial.getImage())
                 .content(testimonial.getContent())
-                .createdAt(testimonial.getCreatedAt())
-                .updatedAt(testimonial.getUpdatedAt())
+                //.createdAt(testimonial.getCreatedAt())
+                //.updatedAt(testimonial.getUpdatedAt())
                 .build();
     }
 
@@ -79,12 +80,13 @@ public class TestimonialController {
         return testimonialList.stream().map(this::toDto).collect(toList());
     }
 
+    //TODO: Borrar lineas comentadas si el rework funciona!
     @Getter
     @Setter
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    private static class TestimonialDTO {
+    public static class TestimonialDTO {
         private Long id;
 
         @NotNull(message = "Field 'name' is required.")
@@ -96,9 +98,9 @@ public class TestimonialController {
         @NotNull(message = "Field 'content' is required.")
         private String content;
 
-        private LocalDateTime createdAt;
+        //private LocalDateTime createdAt;
 
-        private LocalDateTime updatedAt;
+        //private LocalDateTime updatedAt;
 
         private String type = "testimonial";
     }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -123,7 +123,7 @@ name VARCHAR (255) NOT NULL,
 image VARCHAR (255),
 content VARCHAR (255),
 created_at TIMESTAMP DEFAULT NOW(),
-updated_at TIMESTAMP,
+updated_at TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 deleted BIT(1) DEFAULT 0
 );
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -123,7 +123,7 @@ name VARCHAR (255) NOT NULL,
 image VARCHAR (255),
 content VARCHAR (255),
 created_at TIMESTAMP DEFAULT NOW(),
-updated_at TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+updated_at TIMESTAMP,
 deleted BIT(1) DEFAULT 0
 );
 

--- a/src/test/java/com/alkemy/ong/web/controllers/TestimonialControllerTest.java
+++ b/src/test/java/com/alkemy/ong/web/controllers/TestimonialControllerTest.java
@@ -5,7 +5,6 @@ import com.alkemy.ong.data.pagination.PageModel;
 import com.alkemy.ong.data.repositories.TestimonialRepository;
 import com.alkemy.ong.domain.exceptions.ResourceNotFoundException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -68,7 +67,6 @@ public class TestimonialControllerTest {
     @Test
     @WithMockUser(roles = "ADMIN")
     void createTestimonialBadRequest() throws Exception{
-        TestimonialEntity testimonial = createTestimonialEntity(null, null, "http://amazon3.jpg", "Test content");
         TestimonialDTO testimonialDTO = createTestimonialDTO(null, null, "http://amazon3.jpg", "Test content");
 
         mockMvc.perform(post(URL)
@@ -118,7 +116,6 @@ public class TestimonialControllerTest {
     @Test
     @WithMockUser(roles = "ADMIN")
     void updateTestimonialBadRequest() throws Exception{
-        TestimonialEntity testimonialUpdated = createTestimonialEntity(1L, "Testimonial", "http://amazon3.jpg", null);
         TestimonialDTO testimonialDTO = createTestimonialDTO(1L, "Testimonial", "http://amazon3.jpg", null);
 
         mockMvc.perform(put(URL + "/1")
@@ -150,7 +147,7 @@ public class TestimonialControllerTest {
     void deleteTestimonialSuccess() throws Exception{
         TestimonialEntity testimonial = createTestimonialEntity(1L, "Testimonial", "http://amazon3.jpg", "Test content");
         when(testimonialRepository.findById(1L)).thenReturn(Optional.of(testimonial));
-        doNothing().when(testimonialRepository).deleteById(1l);
+        doNothing().when(testimonialRepository).deleteById(1L);
 
         mockMvc.perform(delete(URL+"/1"))
                 .andExpect(status().isNoContent());

--- a/src/test/java/com/alkemy/ong/web/controllers/TestimonialControllerTest.java
+++ b/src/test/java/com/alkemy/ong/web/controllers/TestimonialControllerTest.java
@@ -1,28 +1,31 @@
 package com.alkemy.ong.web.controllers;
 
 import com.alkemy.ong.data.entities.TestimonialEntity;
+import com.alkemy.ong.data.pagination.PageModel;
 import com.alkemy.ong.data.repositories.TestimonialRepository;
 import com.alkemy.ong.domain.exceptions.ResourceNotFoundException;
-import com.alkemy.ong.domain.testimonial.Testimonial;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.MockBeans;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
-
-import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.Optional;
 
+import static com.alkemy.ong.data.utils.PaginationUtils.DEFAULT_PAGE_SIZE;
 import static com.alkemy.ong.web.controllers.TestimonialController.*;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.hamcrest.Matchers.is;
@@ -58,8 +61,6 @@ public class TestimonialControllerTest {
             .andExpect(jsonPath("$.name", is("Testimonial")))
             .andExpect(jsonPath("$.image", is("http://amazon3.jpg")))
             .andExpect(jsonPath("$.content", is("Test content")));
-            //.andExpect(jsonPath("$.createdAt",is("2022-03-29T18:58:56")))
-            //.andExpect(jsonPath("$.updatedAt",is("2022-03-29T18:58:56")));
     }
 
     @Test
@@ -99,8 +100,6 @@ public class TestimonialControllerTest {
                 .andExpect(jsonPath("$.name", is("Testimonial")))
                 .andExpect(jsonPath("$.image", is("http://amazon3.jpg")))
                 .andExpect(jsonPath("$.content", is("Test content")));
-                //.andExpect(jsonPath("$.createdAt",is("2022-03-29T18:58:56")))
-                //.andExpect(jsonPath("$.updatedAt",is("2022-03-29T18:58:56")));
     }
 
     @Test
@@ -148,44 +147,99 @@ public class TestimonialControllerTest {
                 .andExpect(status().isForbidden());
     }
 
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void deleteTestimonialSuccess() throws Exception{
+        TestimonialEntity testimonial = createTestimonialEntity(1L, "Testimonial", "http://amazon3.jpg", "Test content");
+        when(testimonialRepository.findById(1L)).thenReturn(Optional.of(testimonial));
 
-    /**
-     * DTO y Entities Borrar despues solo separación visual
-     */
+        mockMvc.perform(delete(url+"/1"))
+                .andExpect(status().isNoContent());
+    }
 
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void deleteTestimonialNotFound() throws Exception{
+        when(testimonialRepository.findById(3L)).thenThrow(new ResourceNotFoundException(3L, "Testimonial"));
 
-    //TODO: Borrar lineas comentadas si el rework funciona!
+        mockMvc.perform(delete(url+"/3"))
+                .andExpect(status().isNotFound());
+
+        ResourceNotFoundException exceptionThrows = assertThrows(ResourceNotFoundException.class,
+                () -> {testimonialRepository.findById(3L);}, "No Testimonial found with ID 3");
+
+        Assertions.assertEquals("No Testimonial found with ID 3", exceptionThrows.getMessage());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void deleteTestimonialUser() throws Exception{
+        mockMvc.perform(delete(url + "/1"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void findAllTestimonialsSuccess() throws Exception{
+        PageModel<TestimonialEntity> pageModel = buildPageModel();
+
+        when(testimonialRepository.findAll(PageRequest.of(0,DEFAULT_PAGE_SIZE))).thenReturn(new PageImpl<>(pageModel.getBody()));
+
+        mockMvc.perform(get(url+"?page={page}",0)
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(pageModel)))
+                .andExpect(jsonPath("body").isArray())
+                .andExpect(jsonPath("$.body",hasSize(5)))
+                .andExpect(jsonPath("$.body.[0].id",is(1)))
+                .andExpect(jsonPath("$.body.[1].id",is(2)))
+                .andExpect(jsonPath("$.body.[2].id",is(3)))
+                .andExpect(jsonPath("$.body.[3].id",is(4)))
+                .andExpect(jsonPath("$.body.[4].id",is(5)))
+                .andExpect(jsonPath("$.nextPage",is("This is the last page")))
+                .andExpect(jsonPath("$.previuosPage",is("This is the first page")))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void findAllTestimonialsBadRequest() throws Exception{
+        PageModel<TestimonialEntity> pageModel = buildPageModel();
+
+        mockMvc.perform(get(url+"?page=",0)
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(pageModel)))
+                .andExpect(status().isBadRequest());
+    }
+
     private TestimonialEntity createTestimonialEntity(Long id, String name, String image, String content){
         return TestimonialEntity.builder()
                 .id(id)
                 .name(name)
                 .image(image)
                 .content(content)
-                //.createdAt(LocalDateTime.of(2022,03,29,18,58,56))
-                //.updatedAt(LocalDateTime.of(2022,03,29,18,58,56))
                 .build();
     }
 
-    //TODO: Borrar lineas comentadas si el rework funciona!
-    private Testimonial createTestimonial(Long id, String name, String image, String content){
-        return Testimonial.builder()
-                .id(id)
-                .name(name)
-                .image(image)
-                .content(content)
-                //.createdAt(LocalDateTime.of(2022,03,29,18,58,56))
-                //.updatedAt(LocalDateTime.of(2022,03,29,18,58,56))
-                .build();
-    }
-    //TODO: Borrar lineas comentadas si el rework funciona!
     private TestimonialDTO createTestimonialDTO(Long id, String name, String image, String content){
         return TestimonialDTO.builder()
                 .id(id)
                 .name(name)
                 .image(image)
                 .content(content)
-                //.createdAt(LocalDateTime.of(2022,03,29,18,58,56))
-                //.updatedAt(LocalDateTime.of(2022,03,29,18,58,56))
+                .build();
+    }
+
+    private PageModel buildPageModel(){
+        return PageModel.builder()
+                .body(Arrays.asList(
+                        createTestimonialEntity(1L, "Testimonial", "http://amazon3.jpg", "Test content"),
+                        createTestimonialEntity(2L, "Testimonial", "http://amazon3.jpg", "Test content"),
+                        createTestimonialEntity(3L, "Testimonial", "http://amazon3.jpg", "Test content"),
+                        createTestimonialEntity(4L, "Testimonial", "http://amazon3.jpg", "Test content"),
+                        createTestimonialEntity(5L, "Testimonial", "http://amazon3.jpg", "Test content")
+                ))
+                .nextPage("This is the last page")
+                .previousPage("This is the first page")
                 .build();
     }
 }

--- a/src/test/java/com/alkemy/ong/web/controllers/TestimonialControllerTest.java
+++ b/src/test/java/com/alkemy/ong/web/controllers/TestimonialControllerTest.java
@@ -1,0 +1,191 @@
+package com.alkemy.ong.web.controllers;
+
+import com.alkemy.ong.data.entities.TestimonialEntity;
+import com.alkemy.ong.data.repositories.TestimonialRepository;
+import com.alkemy.ong.domain.exceptions.ResourceNotFoundException;
+import com.alkemy.ong.domain.testimonial.Testimonial;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.MockBeans;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static com.alkemy.ong.web.controllers.TestimonialController.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.hamcrest.Matchers.is;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class TestimonialControllerTest {
+
+    @Autowired
+     MockMvc mockMvc;
+    @Autowired
+     ObjectMapper objectMapper;
+
+    @MockBean
+    TestimonialRepository testimonialRepository;
+
+    private final String url = "/testimonials";
+
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void createTestimonial() throws Exception{
+    TestimonialEntity testimonial = createTestimonialEntity(null, "Testimonial", "http://amazon3.jpg", "Test content");
+    TestimonialEntity testimonialSaved = createTestimonialEntity(1L, "Testimonial", "http://amazon3.jpg", "Test content");
+    TestimonialDTO testimonialDTO = createTestimonialDTO(null, "Testimonial", "http://amazon3.jpg", "Test content");
+    when(testimonialRepository.save(testimonial)).thenReturn(testimonialSaved);
+
+    mockMvc.perform(post(url)
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(testimonialDTO)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.id", is(1)))
+            .andExpect(jsonPath("$.name", is("Testimonial")))
+            .andExpect(jsonPath("$.image", is("http://amazon3.jpg")))
+            .andExpect(jsonPath("$.content", is("Test content")));
+            //.andExpect(jsonPath("$.createdAt",is("2022-03-29T18:58:56")))
+            //.andExpect(jsonPath("$.updatedAt",is("2022-03-29T18:58:56")));
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void createTestimonialBadRequest() throws Exception{
+        TestimonialEntity testimonial = createTestimonialEntity(null, "", "http://amazon3.jpg", "Test content");
+        TestimonialEntity testimonialSaved = createTestimonialEntity(1L, "", "http://amazon3.jpg", "Test content");
+        TestimonialDTO testimonialDTO = createTestimonialDTO(null, "", "http://amazon3.jpg", "Test content");
+        when(testimonialRepository.save(testimonial)).thenReturn(testimonialSaved);
+
+        mockMvc.perform(post(url)
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(testimonialDTO)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void createTestimonialUser() throws Exception {
+        mockMvc.perform(post(url))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void updateTestimonial() throws Exception{
+        TestimonialEntity testimonialUpdated = createTestimonialEntity(1L, "Testimonial", "http://amazon3.jpg", "Test content");
+        TestimonialDTO testimonialDTO = createTestimonialDTO(1L, "Testimonial", "http://amazon3.jpg", "Test content");
+        when(testimonialRepository.findById(1L)).thenReturn(Optional.of(testimonialUpdated));
+        when(testimonialRepository.save(testimonialUpdated)).thenReturn(testimonialUpdated);
+
+        mockMvc.perform(put(url + "/1")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(testimonialDTO)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id", is(1)))
+                .andExpect(jsonPath("$.name", is("Testimonial")))
+                .andExpect(jsonPath("$.image", is("http://amazon3.jpg")))
+                .andExpect(jsonPath("$.content", is("Test content")));
+                //.andExpect(jsonPath("$.createdAt",is("2022-03-29T18:58:56")))
+                //.andExpect(jsonPath("$.updatedAt",is("2022-03-29T18:58:56")));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void updateTestimonialNotFount() throws Exception{
+        when(testimonialRepository.findById(3L)).thenThrow(new ResourceNotFoundException(3L, "Testimonial"));
+        TestimonialDTO testimonialDTO = createTestimonialDTO(3L, "Testimonial", "http://amazon3.jpg", "Test content");
+
+        mockMvc.perform(put(url + "/3")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(testimonialDTO)))
+                .andExpect(status().isNotFound());
+
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void updateTestimonialBadRequest() throws Exception{
+        TestimonialEntity testimonialUpdated = createTestimonialEntity(1L, "Testimonial", "http://amazon3.jpg", null);
+        TestimonialDTO testimonialDTO = createTestimonialDTO(1L, "Testimonial", "http://amazon3.jpg", null);
+        when(testimonialRepository.findById(1L)).thenReturn(Optional.of(testimonialUpdated));
+        when(testimonialRepository.save(testimonialUpdated)).thenReturn(testimonialUpdated);
+
+        mockMvc.perform(put(url + "/1")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(testimonialDTO)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void updateTestimonialBadId() throws Exception{
+        TestimonialDTO testimonialDTO = createTestimonialDTO(1L, "Testimonial", "http://amazon3.jpg", "Test content");
+
+        mockMvc.perform(put(url + "/5")
+                    .contentType(APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(testimonialDTO)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void updateTestimonialUser() throws Exception{
+        mockMvc.perform(put(url + "/1"))
+                .andExpect(status().isForbidden());
+    }
+
+
+    /**
+     * DTO y Entities Borrar despues solo separación visual
+     */
+
+
+    //TODO: Borrar lineas comentadas si el rework funciona!
+    private TestimonialEntity createTestimonialEntity(Long id, String name, String image, String content){
+        return TestimonialEntity.builder()
+                .id(id)
+                .name(name)
+                .image(image)
+                .content(content)
+                //.createdAt(LocalDateTime.of(2022,03,29,18,58,56))
+                //.updatedAt(LocalDateTime.of(2022,03,29,18,58,56))
+                .build();
+    }
+
+    //TODO: Borrar lineas comentadas si el rework funciona!
+    private Testimonial createTestimonial(Long id, String name, String image, String content){
+        return Testimonial.builder()
+                .id(id)
+                .name(name)
+                .image(image)
+                .content(content)
+                //.createdAt(LocalDateTime.of(2022,03,29,18,58,56))
+                //.updatedAt(LocalDateTime.of(2022,03,29,18,58,56))
+                .build();
+    }
+    //TODO: Borrar lineas comentadas si el rework funciona!
+    private TestimonialDTO createTestimonialDTO(Long id, String name, String image, String content){
+        return TestimonialDTO.builder()
+                .id(id)
+                .name(name)
+                .image(image)
+                .content(content)
+                //.createdAt(LocalDateTime.of(2022,03,29,18,58,56))
+                //.updatedAt(LocalDateTime.of(2022,03,29,18,58,56))
+                .build();
+    }
+}


### PR DESCRIPTION
Tiempo Estimado: 8 horas.
Realize cambios en los campos de auditoria de Testimonials y en el squema.sql para que todos los campos se generen solos y los maneje la db.
Realice el Test al controlador TestimonialController.
Evidencias en JIRA